### PR TITLE
feat: implement dynamic user avatars using UI Avatars API

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -2349,9 +2349,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
       "dev": true,
       "funding": [
         {
@@ -2366,7 +2366,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/carstream": {
       "version": "2.3.0",

--- a/webapp/src/hooks/useAuth.ts
+++ b/webapp/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { create } from "@web3-storage/w3up-client";
 import * as DID from "@ipld/dag-ucan/did";
 import * as Delegation from "@ucanto/core/delegation";
 import toast from "react-hot-toast";
+import { generateAvatarUrl } from "../utils/avatar";
 
 interface AuthContextType {
   user: User | null;
@@ -97,8 +98,7 @@ export const useAuthProvider = (): AuthContextType => {
       const newUser: User = {
         email: userEmail,
         spaceDid: savedSpaceDid || (client.currentSpace())?.did(),
-        avatar:
-          "https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&cs=tinysrgb&w=150&h=150&fit=crop",
+        avatar: generateAvatarUrl(userEmail),
       };
 
       localStorage.setItem("storacha-session", JSON.stringify(newUser));

--- a/webapp/src/utils/avatar.ts
+++ b/webapp/src/utils/avatar.ts
@@ -1,0 +1,19 @@
+/**
+ * Generates an avatar URL for a given email using UI Avatars service
+ * @param email User's email address
+ * @returns URL for the avatar image
+ */
+export const generateAvatarUrl = (email: string): string => {
+  const name = email.split('@')[0];
+  
+  const options = {
+    name: encodeURIComponent(name),
+    background: '7C3AED',
+    color: 'fff',
+    size: 150,
+  };
+
+  return `https://ui-avatars.com/api/?${Object.entries(options)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&')}`;
+};


### PR DESCRIPTION


Replaced static profile images with dynamic avatars generated via UI Avatars, which use user email initials, brand colors, and consistent sizing.

### Changes

* Added `generateAvatarUrl` util (`utils/avatar.ts`)
* Updated `useAuth.ts` to assign dynamic avatars
* Configured size (150x150), purple background `#7C3AED`, white text

### Preview

<img width="195" height="77" alt="image" src="https://github.com/user-attachments/assets/2415915f-e80e-4936-9558-8710ee1ec931" />  

